### PR TITLE
Linked Data Context

### DIFF
--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -11,7 +11,6 @@
       "proto":"https://thehabes.github.io/GeoreferencePrototype/vocab/new_terms.md#",
       "PixelCoords":{
          "@id":"proto:PixelCoords",
-         "@container":"@list",
          "@context":{
             "value":{
                "@id":"rdf:value",

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -1,5 +1,6 @@
 {
    "@context":{
+   	  "@version": 1.1,
       "geo":"https://purl.org/geojson/vocab#",
       "iiif_prezi":"http://iiif.io/api/presentation/3#",
       "iiif_image":"http://iiif.io/api/image/3#",

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -1,6 +1,6 @@
 {
    "@context":{
-   	  "@version": 1.1,
+      "@version":1.1,
       "geo":"https://purl.org/geojson/vocab#",
       "iiif_prezi":"http://iiif.io/api/presentation/3#",
       "iiif_image":"http://iiif.io/api/image/3#",
@@ -8,7 +8,20 @@
       "as":"http://www.w3.org/ns/activitystreams#",
       "foaf":"http://xmlns.com/foaf/0.1/",
       "proto":"https://thehabes.github.io/GeoreferencePrototype/vocab/new_terms.md#",
-      "PixelCoords" : "proto:PixelCoords",
+      "PixelCoords":{
+         "@id":"proto:PixelCoords",
+         "@container":"@list",
+         "@context":{
+            "value":{
+               "@id":"rdf:value",
+               "@container":"@list"
+            }
+         }
+      },
+      "ControlPoints":{
+         "@id":"proto:ControlPoints",
+         "@container":"@list"
+      },
       "properties":{
          "@id":"geo:properties",
          "@context":{

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -7,10 +7,12 @@
       "rdfs":"http://www.w3.org/2000/01/rdf-schema#",
       "as":"http://www.w3.org/ns/activitystreams#",
       "foaf":"http://xmlns.com/foaf/0.1/",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
       "proto":"https://thehabes.github.io/GeoreferencePrototype/vocab/new_terms.md#",
       "PixelCoords":{
          "@id":"proto:PixelCoords",
          "@container":"@list",
+         "@type" : "xsd:float",
          "@context":{
             "value":{
                "@id":"rdf:value",
@@ -53,7 +55,8 @@
             },
             "pixel_coords":{
                "@id":"proto:pixel_coords",
-               "@container":"@list"
+               "@container":"@list",
+               "@type" : "xsd:float",
             },
             "pic":{
                "@id":"foaf:depiction",

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -25,6 +25,7 @@
          "@container":"@list",
          "@type" : "proto:PixelCoords"
       },
+      "georeferencing" : "proto:georeferencing",
       "properties":{
          "@id":"geo:properties",
          "@context":{

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -1,32 +1,42 @@
 {
-  "@context": {
-    "geojson": "https://purl.org/geojson/vocab#",
-    "Feature": "geojson:Feature",
-    "FeatureCollection": "geojson:FeatureCollection",
-    "GeometryCollection": "geojson:GeometryCollection",
-    "LineString": "geojson:LineString",
-    "MultiLineString": "geojson:MultiLineString",
-    "MultiPoint": "geojson:MultiPoint",
-    "MultiPolygon": "geojson:MultiPolygon",
-    "Point": "geojson:Point",
-    "Polygon": "geojson:Polygon",
-    "bbox": {
-      "@container": "@list",
-      "@id": "geojson:bbox"
-    },
-    "coordinates": {
-      "@container": "@list",
-      "@id": "geojson:coordinates"
-    },
-    "features": {
-      "@container": "@set",
-      "@id": "geojson:features"
-    },
-    "geometry": "geojson:geometry",
-    "id": "@id",
-    "properties": "geojson:properties",
-    "type": "@type",
-    "description": "http://purl.org/dc/terms/description",
-    "title": "http://purl.org/dc/terms/title"
-  }
+	"@context":{
+		"geo":"https://purl.org/geojson/vocab#",
+		"iiif_prezi" : "http://iiif.io/api/presentation/3#",
+		"iiif_image": "http://iiif.io/api/image/3#",
+		"rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+		"as": "http://www.w3.org/ns/activitystreams#",
+		"foaf":"http://xmlns.com/foaf/0.1/",
+		"proto" : "https://thehabes.github.io/GeoreferencePrototype/vocab/new_terms.md#",
+		"properties":{
+			"@id" : "geo:properties",
+		    "@context": {
+		        "label": {
+		            "@id": "rdfs:label",
+		            "@container": ["@language", "@set"],
+		            "@context": {
+		              "none": "@none"
+		            }
+	          	},
+	          	"summary": {
+				    "@id": "as:summary",
+				    "@container": ["@language", "@set"],
+				    "@context": {
+			  	    	"none": "@none"
+				    }             
+	      		},
+	      		"metadata": {
+			      "@type": "@id",
+			      "@id": "iiif_prezi:metadataEntries",
+			      "@container": "@list"
+			    },
+	          	"pixel_coords":{
+	          		"@id" : "proto:pixel_coords",
+	          		"@container" : "@list",
+	          	},
+	          	"pic": {
+			        "@id": "foaf:depiction",
+			        "@type": "@id"
+		      	}
+		}	
+	}
 }

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -20,7 +20,8 @@
       },
       "ControlPoints":{
          "@id":"proto:ControlPoints",
-         "@container":"@list"
+         "@container":"@list",
+         "@type" : "proto:PixelCoords"
       },
       "properties":{
          "@id":"geo:properties",

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -7,6 +7,7 @@
       "rdfs":"http://www.w3.org/2000/01/rdf-schema#",
       "as":"http://www.w3.org/ns/activitystreams#",
       "foaf":"http://xmlns.com/foaf/0.1/",
+      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
       "xsd": "http://www.w3.org/2001/XMLSchema#",
       "proto":"https://thehabes.github.io/GeoreferencePrototype/vocab/new_terms.md#",
       "PixelCoords":{

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -1,42 +1,49 @@
 {
-	"@context":{
-		"geo":"https://purl.org/geojson/vocab#",
-		"iiif_prezi" : "http://iiif.io/api/presentation/3#",
-		"iiif_image": "http://iiif.io/api/image/3#",
-		"rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-		"as": "http://www.w3.org/ns/activitystreams#",
-		"foaf":"http://xmlns.com/foaf/0.1/",
-		"proto" : "https://thehabes.github.io/GeoreferencePrototype/vocab/new_terms.md#",
-		"properties":{
-			"@id" : "geo:properties",
-		    "@context": {
-		        "label": {
-		            "@id": "rdfs:label",
-		            "@container": ["@language", "@set"],
-		            "@context": {
-		              "none": "@none"
-		            }
-	          	},
-	          	"summary": {
-				    "@id": "as:summary",
-				    "@container": ["@language", "@set"],
-				    "@context": {
-			  	    	"none": "@none"
-				    }             
-	      		},
-	      		"metadata": {
-			      "@type": "@id",
-			      "@id": "iiif_prezi:metadataEntries",
-			      "@container": "@list"
-			    },
-	          	"pixel_coords":{
-	          		"@id" : "proto:pixel_coords",
-	          		"@container" : "@list",
-	          	},
-	          	"pic": {
-			        "@id": "foaf:depiction",
-			        "@type": "@id"
-		      	}
-		}	
-	}
+   "@context":{
+      "geo":"https://purl.org/geojson/vocab#",
+      "iiif_prezi":"http://iiif.io/api/presentation/3#",
+      "iiif_image":"http://iiif.io/api/image/3#",
+      "rdfs":"http://www.w3.org/2000/01/rdf-schema#",
+      "as":"http://www.w3.org/ns/activitystreams#",
+      "foaf":"http://xmlns.com/foaf/0.1/",
+      "proto":"https://thehabes.github.io/GeoreferencePrototype/vocab/new_terms.md#",
+      "properties":{
+         "@id":"geo:properties",
+         "@context":{
+            "label":{
+               "@id":"rdfs:label",
+               "@container":[
+                  "@language",
+                  "@set"
+               ],
+               "@context":{
+                  "none":"@none"
+               }
+            },
+            "summary":{
+               "@id":"as:summary",
+               "@container":[
+                  "@language",
+                  "@set"
+               ],
+               "@context":{
+                  "none":"@none"
+               }
+            },
+            "metadata":{
+               "@type":"@id",
+               "@id":"iiif_prezi:metadataEntries",
+               "@container":"@list"
+            },
+            "pixel_coords":{
+               "@id":"proto:pixel_coords",
+               "@container":"@list"
+            },
+            "pic":{
+               "@id":"foaf:depiction",
+               "@type":"@id"
+            }
+         }
+      }
+   }
 }

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -12,11 +12,11 @@
       "PixelCoords":{
          "@id":"proto:PixelCoords",
          "@container":"@list",
-         "@type" : "xsd:float",
          "@context":{
             "value":{
                "@id":"rdf:value",
-               "@container":"@list"
+               "@container":"@list",
+               "@type" : "xsd:float"
             }
          }
       },

--- a/context-extensions/geojson-ext.json
+++ b/context-extensions/geojson-ext.json
@@ -8,6 +8,7 @@
       "as":"http://www.w3.org/ns/activitystreams#",
       "foaf":"http://xmlns.com/foaf/0.1/",
       "proto":"https://thehabes.github.io/GeoreferencePrototype/vocab/new_terms.md#",
+      "PixelCoords" : "proto:PixelCoords",
       "properties":{
          "@id":"geo:properties",
          "@context":{

--- a/prototypes/prototype-composite-body.json
+++ b/prototypes/prototype-composite-body.json
@@ -10,7 +10,7 @@
     {
       "@id": "https://data.allmaps.org/annotations/i/yT5Z6epJ7vi7BeLP/m/pVJemU2Kcq4C8HTs",
       "type": "Annotation",
-      "motivation": "tagging",
+      "motivation": "georeferencing",
       "body": {
         "type": "Composite",
         "items": [
@@ -56,7 +56,6 @@
           },
           {
             "type": "FeatureCollection",
-            "purpose": " ?? georeferencing ?? ",
             "features": [
               {
                 "type": "Feature",
@@ -114,7 +113,7 @@
     {
       "@id": "https://data.allmaps.org/annotations/i/yT5Z6epJ7vi7BeLP/m/EvBivpkw7ty4CSdJ",
       "type": "Annotation",
-      "motivation": "tagging",
+      "motivation": "georeferencing",
       "body": {
         "type": "Composite",
         "items": [
@@ -146,7 +145,6 @@
           },
           {
             "type": "FeatureCollection",
-            "purpose": " ?? georeferencing ?? ",
             "features": [
               {
                 "type": "Feature",

--- a/prototypes/prototype-composite-body.json
+++ b/prototypes/prototype-composite-body.json
@@ -96,7 +96,7 @@
         ]
       },
       "target": {
-        "type": "PixelCoords",
+        "type": "Image",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {
@@ -186,7 +186,7 @@
         ]
       },
       "target": {
-        "type": "PixelCoords",
+        "type": "Image",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {

--- a/prototypes/prototype-composite-body.json
+++ b/prototypes/prototype-composite-body.json
@@ -2,6 +2,7 @@
   "@id": "https://data.allmaps.org/annotations/m/4qzVfHU7rDgRqP7q",
   "type": "AnnotationPage",
   "@context": [
+    "https://thehabes.github.io/GeoreferencePrototype/context-extensions/geojson-ext.json",
     "http://geojson.org/geojson-ld/geojson-context.jsonld",
     "http://iiif.io/api/presentation/3/context.json"
   ],
@@ -17,35 +18,35 @@
             "type": "ControlPoints",
             "items": [
               {
-                "type": "Image",
+                "type": "PixelCoords",
                 "value": [
                   1823,
                   6656
                 ]
               },
               {
-                "type": "Image",
+                "type": "PixelCoords",
                 "value": [
                   1360,
                   4110
                 ]
               },
               {
-                "type": "Image",
+                "type": "PixelCoords",
                 "value": [
                   1360,
                   4110
                 ]
               },
               {
-                "type": "Image",
+                "type": "PixelCoords",
                 "value": [
                   1360,
                   4110
                 ]
               },
               {
-                "type": "Image",
+                "type": "PixelCoords",
                 "value": [
                   2363,
                   4643
@@ -95,7 +96,7 @@
         ]
       },
       "target": {
-        "type": "Image",
+        "type": "PixelCoords",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {
@@ -121,21 +122,21 @@
             "type": "ControlPoints",
             "items": [
               {
-                "type": "Image",
+                "type": "PixelCoords",
                 "value": [
                   3525,
                   622
                 ]
               },
               {
-                "type": "Image",
+                "type": "PixelCoords",
                 "value": [
                   2840,
                   3153
                 ]
               },
               {
-                "type": "Image",
+                "type": "PixelCoords",
                 "value": [
                   4493,
                   4795
@@ -185,7 +186,7 @@
         ]
       },
       "target": {
-        "type": "Image",
+        "type": "PixelCoords",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {

--- a/prototypes/prototype-two-bodies.json
+++ b/prototypes/prototype-two-bodies.json
@@ -2,6 +2,7 @@
   "@id": "https://data.allmaps.org/annotations/m/4qzVfHU7rDgRqP7q",
   "type": "AnnotationPage",
   "@context": [
+    "https://thehabes.github.io/GeoreferencePrototype/context-extensions/geojson-ext.json",
     "http://geojson.org/geojson-ld/geojson-context.jsonld",
     "http://iiif.io/api/presentation/3/context.json"
   ],
@@ -15,35 +16,35 @@
           "type": "ControlPoints",
           "items": [
             {
-              "type": "Image",
+              "type": "PixelCoords",
               "value": [
                 1823,
                 6656
               ]
             },
             {
-              "type": "Image",
+              "type": "PixelCoords",
               "value": [
                 1360,
                 4110
               ]
             },
             {
-              "type": "Image",
+              "type": "PixelCoords",
               "value": [
                 1360,
                 4110
               ]
             },
             {
-              "type": "Image",
+              "type": "PixelCoords",
               "value": [
                 1360,
                 4110
               ]
             },
             {
-              "type": "Image",
+              "type": "PixelCoords",
               "value": [
                 2363,
                 4643
@@ -92,7 +93,7 @@
         }
       ],
       "target": {
-        "type": "Image",
+        "type": "PixelCoords",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {
@@ -116,21 +117,21 @@
           "type": "ControlPoints",
           "items": [
             {
-              "type": "Image",
+              "type": "PixelCoords",
               "value": [
                 3525,
                 622
               ]
             },
             {
-              "type": "Image",
+              "type": "PixelCoords",
               "value": [
                 2840,
                 3153
               ]
             },
             {
-              "type": "Image",
+              "type": "PixelCoords",
               "value": [
                 4493,
                 4795
@@ -179,7 +180,7 @@
         }
       ],
       "target": {
-        "type": "Image",
+        "type": "PixelCoords",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {

--- a/prototypes/prototype-two-bodies.json
+++ b/prototypes/prototype-two-bodies.json
@@ -10,7 +10,7 @@
     {
       "@id": "https://data.allmaps.org/annotations/i/yT5Z6epJ7vi7BeLP/m/pVJemU2Kcq4C8HTs",
       "type": "Annotation",
-      "motivation": "tagging",
+      "motivation": "georeferencing",
       "body": [
         {
           "type": "ControlPoints",
@@ -54,7 +54,6 @@
         },
         {
           "type": "FeatureCollection",
-          "purpose": " ?? georeferencing ?? ",
           "features": [
             {
               "type": "Feature",
@@ -111,7 +110,7 @@
     {
       "@id": "https://data.allmaps.org/annotations/i/yT5Z6epJ7vi7BeLP/m/EvBivpkw7ty4CSdJ",
       "type": "Annotation",
-      "motivation": "tagging",
+      "motivation": "georeferencing",
       "body": [
         {
           "type": "ControlPoints",
@@ -141,7 +140,6 @@
         },
         {
           "type": "FeatureCollection",
-          "purpose": " ?? georeferencing ?? ",
           "features": [
             {
               "type": "Feature",

--- a/prototypes/prototype-two-bodies.json
+++ b/prototypes/prototype-two-bodies.json
@@ -93,7 +93,7 @@
         }
       ],
       "target": {
-        "type": "PixelCoords",
+        "type": "Image",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {
@@ -180,7 +180,7 @@
         }
       ],
       "target": {
-        "type": "PixelCoords",
+        "type": "Image",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {

--- a/prototypes/prototype.json
+++ b/prototypes/prototype.json
@@ -2,6 +2,7 @@
   "@id": "https://data.allmaps.org/annotations/m/4qzVfHU7rDgRqP7q",
   "type": "AnnotationPage",
   "@context": [
+    "https://thehabes.github.io/GeoreferencePrototype/context-extensions/geojson-ext.json",
     "http://geojson.org/geojson-ld/geojson-context.jsonld",
     "http://iiif.io/api/presentation/3/context.json"
   ],
@@ -17,7 +18,7 @@
           {
             "type": "Feature",
             "properties": {
-              "image": [
+              "pixel_coords": [
                 1823,
                 6656
               ]
@@ -33,7 +34,7 @@
           {
             "type": "Feature",
             "properties": {
-              "image": [
+              "pixel_coords": [
                 1360,
                 4110
               ]
@@ -49,7 +50,7 @@
           {
             "type": "Feature",
             "properties": {
-              "image": [
+              "pixel_coords": [
                 2363,
                 4643
               ]
@@ -65,7 +66,7 @@
         ]
       },
       "target": {
-        "type": "Image",
+        "type": "pixel_coords",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {
@@ -91,7 +92,7 @@
           {
             "type": "Feature",
             "properties": {
-              "image": [
+              "pixel_coords": [
                 3525,
                 622
               ]
@@ -107,7 +108,7 @@
           {
             "type": "Feature",
             "properties": {
-              "image": [
+              "pixel_coords": [
                 2840,
                 3153
               ]
@@ -123,7 +124,7 @@
           {
             "type": "Feature",
             "properties": {
-              "image": [
+              "pixel_coords": [
                 4493,
                 4795
               ]
@@ -139,7 +140,7 @@
         ]
       },
       "target": {
-        "type": "Image",
+        "type": "pixel_coords",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {

--- a/prototypes/prototype.json
+++ b/prototypes/prototype.json
@@ -10,10 +10,9 @@
     {
       "@id": "https://data.allmaps.org/annotations/i/yT5Z6epJ7vi7BeLP/m/pVJemU2Kcq4C8HTs",
       "type": "Annotation",
-      "motivation": "tagging",
+      "motivation": "georeferencing",
       "body": {
         "type": "FeatureCollection",
-        "purpose": " ?? georeferencing ?? ",
         "features": [
           {
             "type": "Feature",
@@ -84,10 +83,9 @@
     {
       "@id": "https://data.allmaps.org/annotations/i/yT5Z6epJ7vi7BeLP/m/EvBivpkw7ty4CSdJ",
       "type": "Annotation",
-      "motivation": "tagging",
+      "motivation": "georeferencing",
       "body": {
         "type": "FeatureCollection",
-        "purpose": " ?? georeferencing ?? ",
         "features": [
           {
             "type": "Feature",

--- a/prototypes/prototype.json
+++ b/prototypes/prototype.json
@@ -66,7 +66,7 @@
         ]
       },
       "target": {
-        "type": "pixel_coords",
+        "type": "Image",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {
@@ -140,7 +140,7 @@
         ]
       },
       "target": {
-        "type": "pixel_coords",
+        "type": "Image",
         "source": "https://tile.loc.gov/image-services/iiif/service:gmd:gmd384:g3842:g3842c:ct008615/full/1000,/0/default.jpg",
         "service": [
           {

--- a/vocab/new-terms.md
+++ b/vocab/new-terms.md
@@ -2,7 +2,7 @@
 
 
 ## ControlPoints
-A set of PixelCoords that are the control points for warping an image into geocoordinate space in a Web Map system.  The PixelCoords objects are contained within the "items" property.
+A ControlPoint is a set of pairs <PixelCoords, GeoJSON Point>.
 
 ## PixelCoords
 PixelCoords contain a single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in Web Map systems.  The geocoordinates are found inside the "value" property.  

--- a/vocab/new-terms.md
+++ b/vocab/new-terms.md
@@ -5,8 +5,7 @@
 A set of PixelCoords that are the control points for warping an image into geocoordinate space in a Web Map system.  The PixelCoords objects are contained within the "items" property.
 
 ## PixelCoords
-PixelCoords contain a single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in a given Web Map system.  The coordinates are found inside the "value" property.  
+PixelCoords contain a single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in Web Map systems.  The geocoordinates are found inside the "value" property.  
 
 ## pixel_coords
-The pixel location of where a resources goes in relation to its geographic coordinates (I know this is weak Bert, help me out).
-
+A single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in Web Map systems.

--- a/vocab/new-terms.md
+++ b/vocab/new-terms.md
@@ -9,3 +9,6 @@ PixelCoords contain a single pixel coordinate point that represents a control po
 
 ## pixel_coords
 A single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in Web Map systems.
+
+## georeferencing
+An extention allowing for a georeferencing motivation or purpose.  This can be on the Annotation as a motivation or within the body of an Annotation as a purpose.  This lets clients know that this Annotation will contain the data required to georeference the targeted resource into WGS84 space.  

--- a/vocab/new-terms.md
+++ b/vocab/new-terms.md
@@ -2,10 +2,10 @@
 
 
 ## ControlPoints
-A set of PixelCoords that are the control points for warping an image into geocoordinate space in a Web Map system.
+A set of PixelCoords that are the control points for warping an image into geocoordinate space in a Web Map system.  The PixelCoords objects are contained within the "items" property.
 
 ## PixelCoords
-PixelCoords contain a single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in a given Web Map system.  
+PixelCoords contain a single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in a given Web Map system.  The coordinates are found inside the "value" property.  
 
 ## pixel_coords
 The pixel location of where a resources goes in relation to its geographic coordinates (I know this is weak Bert, help me out).

--- a/vocab/new-terms.md
+++ b/vocab/new-terms.md
@@ -11,4 +11,4 @@ PixelCoords contain a single pixel coordinate point that represents a control po
 A single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in Web Map systems.
 
 ## georeferencing
-An extention allowing for a georeferencing motivation or purpose.  This can be on the Annotation as a motivation or within the body of an Annotation as a purpose.  This lets clients know that this Annotation will contain the data required to georeference the targeted resource into WGS84 space.  
+A motivation or purpose.  This can be on the Annotation as a motivation or within the body of an Annotation as a purpose.  This lets clients know that this Annotation will contain the data required to georeference the targeted resource into WGS84 space.  

--- a/vocab/new-terms.md
+++ b/vocab/new-terms.md
@@ -1,5 +1,9 @@
 # New terms used in context extensions and prototypes that have no RDF or other vocabulary
 
+
+## PixelCoords
+PixelCoords contain a single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in a given Web Map system.  
+
 ## pixel_coords
 The pixel location of where a resources goes in relation to its geographic coordinates (I know this is weak Bert, help me out).
 

--- a/vocab/new-terms.md
+++ b/vocab/new-terms.md
@@ -1,6 +1,9 @@
 # New terms used in context extensions and prototypes that have no RDF or other vocabulary
 
 
+## ControlPoints
+A set of PixelCoords that are the control points for warping an image into geocoordinate space in a Web Map system.
+
 ## PixelCoords
 PixelCoords contain a single pixel coordinate point that represents a control point for converting between geospatial coordinates and pixel coordinates in a given Web Map system.  
 

--- a/vocab/new-terms.md
+++ b/vocab/new-terms.md
@@ -1,5 +1,5 @@
 # New terms used in context extensions and prototypes that have no RDF or other vocabulary
 
-## pixel
+## pixel_coords
 The pixel location of where a resources goes in relation to its geographic coordinates (I know this is weak Bert, help me out).
 


### PR DESCRIPTION
A IIIF and GeoJSON friendly context extension.  It assumes that it will act as an extension of both.  That means that @contexts must include this context URI alongside the IIIF and GeoJSON context URIs.  It cannot stand alone without absorbing the context terms of those two Linked Data contexts explicitly.

This gives `properties` extra definition.  It specifies what JSON keys must be processed and the expected format of those values.  

With this context we can put data into GeoJSON `properties` directly.  This allows us to have simpler objects since we don't have to rely on specific Linked Data semantics to define first class "must process" data.  